### PR TITLE
style: replace vibrant colors with muted palette

### DIFF
--- a/src/app/widgets/quote-widget/quote-widget.component.css
+++ b/src/app/widgets/quote-widget/quote-widget.component.css
@@ -51,7 +51,7 @@
 .quote-mark {
   font-size: 3rem;
   line-height: 0.8;
-  color: var(--color-accent, #1976d2);
+  color: var(--color-accent, var(--color-accent, #5b7fa6));
   font-family: Georgia, serif;
   opacity: 0.4;
   user-select: none;
@@ -72,7 +72,7 @@
   margin-left: 0.25rem;
   background: none;
   border: none;
-  color: #1976d2;
+  color: var(--color-accent, #5b7fa6);
   font-size: var(--font-size-sm);
   font-family: var(--font-family);
   font-style: normal;
@@ -83,11 +83,11 @@
 }
 
 .read-more-btn:hover {
-  color: #1565c0;
+  color: var(--color-accent-hover, #4a6a8a);
 }
 
 .read-more-btn:focus-visible {
-  outline: 2px solid #1976d2;
+  outline: 2px solid var(--color-accent, #5b7fa6);
   outline-offset: 2px;
   border-radius: 2px;
 }

--- a/src/app/widgets/weather-widget/weather-widget.component.css
+++ b/src/app/widgets/weather-widget/weather-widget.component.css
@@ -111,7 +111,7 @@
 
 .stale-warning {
   font-size: var(--font-size-sm);
-  color: #e65100;
+  color: #a05c28;
   margin-top: 0.25rem;
 }
 
@@ -154,12 +154,12 @@
 }
 
 .city-input:focus {
-  border-color: #1976d2;
+  border-color: var(--color-accent, #5b7fa6);
 }
 
 .city-submit {
   padding: 0.5rem var(--spacing-sm);
-  background: #1976d2;
+  background: var(--color-accent, #5b7fa6);
   color: #ffffff;
   border: none;
   border-radius: var(--radius-sm);
@@ -171,17 +171,17 @@
 }
 
 .city-submit:hover {
-  background: #1565c0;
+  background: var(--color-accent-hover, #4a6a8a);
 }
 
 .city-submit:focus-visible {
-  outline: 2px solid #1976d2;
+  outline: 2px solid var(--color-accent, #5b7fa6);
   outline-offset: 2px;
 }
 
 .city-error {
   font-size: var(--font-size-sm);
-  color: #c62828;
+  color: #9e3030;
 }
 
 /* --- Error state --- */
@@ -205,8 +205,8 @@
 .retry-btn {
   padding: 0.5rem var(--spacing-md);
   background: transparent;
-  color: #1976d2;
-  border: 1px solid #1976d2;
+  color: var(--color-accent, #5b7fa6);
+  border: 1px solid var(--color-accent, #5b7fa6);
   border-radius: var(--radius-sm);
   font-size: var(--font-size-sm);
   font-family: var(--font-family);
@@ -215,12 +215,12 @@
 }
 
 .retry-btn:hover {
-  background: #1976d2;
+  background: var(--color-accent, #5b7fa6);
   color: #ffffff;
 }
 
 .retry-btn:focus-visible {
-  outline: 2px solid #1976d2;
+  outline: 2px solid var(--color-accent, #5b7fa6);
   outline-offset: 2px;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -10,12 +10,14 @@
 /* CSS Custom Properties */
 :root {
   /* Colors */
-  --color-bg: #f5f5f5;
+  --color-bg: #f0f2f5;
   --color-surface: #ffffff;
-  --color-text-primary: #212121;
-  --color-text-secondary: #757575;
-  --color-border: #e0e0e0;
-  --color-shadow: rgba(0, 0, 0, 0.1);
+  --color-text-primary: #2c2c2c;
+  --color-text-secondary: #6b7280;
+  --color-border: #d1d5db;
+  --color-shadow: rgba(0, 0, 0, 0.08);
+  --color-accent: #5b7fa6;
+  --color-accent-hover: #4a6a8a;
 
   /* Spacing */
   --spacing-xs: 0.5rem;


### PR DESCRIPTION
Replaces the vibrant blue accent (#1976d2) and other loud colors with a calmer, more muted slate-blue palette across all widget CSS files.

Closes #2

Generated with [Claude Code](https://claude.ai/code)